### PR TITLE
remove Range.Inclusive subclass (toString), #21548

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -156,9 +156,7 @@ object Source {
   def range(start: Int, end: Int, step: Int): javadsl.Source[Integer, NotUsed] =
     fromIterator[Integer](new function.Creator[util.Iterator[Integer]]() {
       def create(): util.Iterator[Integer] =
-        new Inclusive(start, end, step) {
-          override def toString: String = s"Range($start to $end, step = $step)"
-        }.iterator.asJava.asInstanceOf[util.Iterator[Integer]]
+        Range.inclusive(start, end, step).iterator.asJava.asInstanceOf[util.Iterator[Integer]]
     })
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val junitVersion = "4.12"
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.11.8"), // "2.12.0-M4"
+    crossScalaVersions := Seq("2.11.8"), // "2.12.0-RC1"
     scalaVersion := crossScalaVersions.value.head,
     scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.7"),
     scalaCheckVersion := sys.props.get("akka.build.scalaCheckVersion").getOrElse("1.13.2"),
@@ -28,8 +28,7 @@ object Dependencies {
     },
     java8CompatVersion := {
       scalaVersion.value match {
-        case "2.12.0-M4" => "0.8.0-RC1"
-        case "2.12.0-M5" => "0.8.0-RC3"
+        case x if x.startsWith("2.12.0-RC1") => "0.8.0-RC7"
         case _ => "0.7.0"
       }
     }


### PR DESCRIPTION
- remove Range.Inclusive subclass (toString), #21548
- update java8-compat dependency for Scala 2.12-RC1
